### PR TITLE
Move global context entries to dedicated libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "dependencies": {
     "@frontmeans/dom-primitives": "^1.1.0",
     "@frontmeans/doqry": "^1.0.0",
-    "@frontmeans/namespace-aliaser": "^2.6.0-dev.0",
-    "@frontmeans/render-scheduler": "^1.8.0-dev.0",
+    "@frontmeans/namespace-aliaser": "^2.6.0",
+    "@frontmeans/render-scheduler": "^1.8.0",
     "@proc7ts/amend": "^1.0.0",
     "@proc7ts/context-values": "^7.0.0-dev.13",
     "@proc7ts/primitives": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "dependencies": {
     "@frontmeans/dom-primitives": "^1.1.0",
     "@frontmeans/doqry": "^1.0.0",
-    "@frontmeans/namespace-aliaser": "^2.5.0",
-    "@frontmeans/render-scheduler": "^1.7.0",
+    "@frontmeans/namespace-aliaser": "^2.6.0-dev.0",
+    "@frontmeans/render-scheduler": "^1.8.0-dev.0",
     "@proc7ts/amend": "^1.0.0",
     "@proc7ts/context-values": "^7.0.0-dev.13",
     "@proc7ts/primitives": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@frontmeans/style-producer": "^7.0.0",
     "@proc7ts/fun-events": "^10.5.0",
-    "@wesib/wesib": "^2.0.0-dev.0"
+    "@wesib/wesib": "^2.0.0"
   },
   "dependencies": {
     "@frontmeans/dom-primitives": "^1.1.0",
@@ -49,7 +49,7 @@
     "@types/jsdom": "^16.2.13",
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",
-    "@wesib/wesib": "^2.0.0-dev.0",
+    "@wesib/wesib": "^2.0.0",
     "eslint": "^7.30.0",
     "eslint-plugin-jest": "^24.3.6",
     "gh-pages": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
     "@frontmeans/dom-primitives": "^1.1.0",
     "@frontmeans/doqry": "^1.0.0",
-    "@frontmeans/namespace-aliaser": "^2.6.1",
-    "@frontmeans/render-scheduler": "^1.8.0",
+    "@frontmeans/namespace-aliaser": "^2.6.2",
+    "@frontmeans/render-scheduler": "^1.8.1",
     "@proc7ts/amend": "^1.0.0",
-    "@proc7ts/context-values": "^7.0.0-dev.13",
+    "@proc7ts/context-values": "^7.0.0",
     "@proc7ts/primitives": "^3.0.2",
     "@proc7ts/push-iterator": "^2.6.0",
     "@proc7ts/supply": "^1.2.3"
@@ -41,7 +41,7 @@
     "@frontmeans/render-scheduler": "^1.5.0",
     "@frontmeans/style-producer": "^7.0.0",
     "@jest/globals": "^27.0.6",
-    "@proc7ts/context-builder": "^7.0.0-dev.13",
+    "@proc7ts/context-builder": "^7.0.0",
     "@proc7ts/fun-events": "^10.5.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@run-z/eslint-config": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@frontmeans/dom-primitives": "^1.1.0",
     "@frontmeans/doqry": "^1.0.0",
-    "@frontmeans/namespace-aliaser": "^2.6.0",
+    "@frontmeans/namespace-aliaser": "^2.6.1",
     "@frontmeans/render-scheduler": "^1.8.0",
     "@proc7ts/amend": "^1.0.0",
     "@proc7ts/context-values": "^7.0.0-dev.13",

--- a/src/component-styp-dom.format-config.ts
+++ b/src/component-styp-dom.format-config.ts
@@ -1,6 +1,7 @@
 import { nodeDocument } from '@frontmeans/dom-primitives';
+import { NamespaceAliaser } from '@frontmeans/namespace-aliaser';
 import { StypDomFormatConfig } from '@frontmeans/style-producer';
-import { ComponentContext, ComponentRenderScheduler, DefaultNamespaceAliaser, RenderDef } from '@wesib/wesib';
+import { ComponentContext, ComponentRenderScheduler, RenderDef } from '@wesib/wesib';
 import { ComponentStypFormat, ComponentStypFormatConfig } from './component-styp-format';
 
 /**
@@ -8,7 +9,7 @@ import { ComponentStypFormat, ComponentStypFormatConfig } from './component-styp
  *
  * Schedules style rendering in `ComponentRenderScheduler` by default.
  *
- * Utilizes `DefaultNamespaceAliaser` by default.
+ * Utilizes `NamespaceAliaser` by default.
  *
  * @param format - Target component style production format.
  * @param config - Original component style production format configuration.
@@ -31,7 +32,7 @@ export function componentStypDomFormatConfig(
     parent: config.parent || context.contentRoot,
     rootSelector: [],
     scheduler: config.scheduler || defaultStypRenderScheduler(context, render),
-    nsAlias: config.nsAlias || context.get(DefaultNamespaceAliaser),
+    nsAlias: config.nsAlias || context.get(NamespaceAliaser),
     renderer: format.renderer(config),
   };
 }

--- a/src/component-styp-dom.format.spec.ts
+++ b/src/component-styp-dom.format.spec.ts
@@ -1,10 +1,10 @@
-import { newNamespaceAliaser } from '@frontmeans/namespace-aliaser';
 import { immediateRenderScheduler, RenderSchedule, RenderScheduleOptions } from '@frontmeans/render-scheduler';
 import { StypRenderer } from '@frontmeans/style-producer';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { CxBuilder, cxConstAsset } from '@proc7ts/context-builder';
+import { CxGlobals } from '@proc7ts/context-values';
 import { noop } from '@proc7ts/primitives';
-import { ComponentContext, ComponentRenderScheduler, DefaultNamespaceAliaser } from '@wesib/wesib';
+import { ComponentContext, ComponentRenderScheduler } from '@wesib/wesib';
 import { Mock } from 'jest-mock';
 import { componentStypDomFormatConfig } from './component-styp-dom.format-config';
 import { ComponentStypFormat } from './component-styp-format';
@@ -22,12 +22,12 @@ describe('componentStypDomFormatConfig', () => {
       get,
     } as Partial<ComponentContext> as ComponentContext));
 
-    cxBuilder.provide(cxConstAsset(DefaultNamespaceAliaser, newNamespaceAliaser()));
-
     scheduler = jest.fn(immediateRenderScheduler);
     cxBuilder.provide(cxConstAsset(ComponentRenderScheduler, scheduler));
 
     context = cxBuilder.context;
+    cxBuilder.provide(cxConstAsset(CxGlobals, context));
+
     format = {
       context,
       renderer(): StypRenderer {

--- a/src/component-styp-format.spec.ts
+++ b/src/component-styp-format.spec.ts
@@ -1,6 +1,6 @@
 import { nodeDocument } from '@frontmeans/dom-primitives';
 import { doqryPicker, DoqryPicker, DoqrySelector } from '@frontmeans/doqry';
-import { newNamespaceAliaser } from '@frontmeans/namespace-aliaser';
+import { NamespaceAliaser, newNamespaceAliaser } from '@frontmeans/namespace-aliaser';
 import {
   immediateRenderScheduler,
   newManualRenderScheduler,
@@ -10,6 +10,7 @@ import {
 import { produceBasicStyle, StypFormatConfig, StypRenderer, stypRoot } from '@frontmeans/style-producer';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { CxBuilder, cxConstAsset } from '@proc7ts/context-builder';
+import { CxGlobals } from '@proc7ts/context-values';
 import { trackValue } from '@proc7ts/fun-events';
 import { Supply } from '@proc7ts/supply';
 import {
@@ -17,7 +18,6 @@ import {
   ComponentContext,
   ComponentRenderScheduler,
   ComponentState,
-  DefaultNamespaceAliaser,
   ShadowContentRoot,
 } from '@wesib/wesib';
 import { Mock } from 'jest-mock';
@@ -56,12 +56,12 @@ describe('ComponentStypDomFormat', () => {
 
     ready.it = context = cxBuilder.context;
 
+    cxBuilder.provide(cxConstAsset(CxGlobals, context));
     cxBuilder.provide(cxConstAsset(ComponentContext, context));
     cxBuilder.provide(cxConstAsset(BootstrapContext, context as any));
   });
 
   beforeEach(() => {
-    cxBuilder.provide(cxConstAsset(DefaultNamespaceAliaser, newNamespaceAliaser()));
     cxBuilder.provide(cxConstAsset(ComponentState, new ComponentState()));
   });
 
@@ -162,7 +162,7 @@ describe('ComponentStypDomFormat', () => {
 
     describe('nsAlias', () => {
       it('defaults to default namespace alias', () => {
-        expect(format.config()).toMatchObject({ nsAlias: context.get(DefaultNamespaceAliaser) });
+        expect(format.config()).toMatchObject({ nsAlias: context.get(NamespaceAliaser) });
       });
       it('respects explicit value', () => {
 

--- a/src/component-styp-format.ts
+++ b/src/component-styp-format.ts
@@ -70,7 +70,7 @@ export interface ComponentStypFormatConfig extends StypFormatConfig {
   /**
    * Namespace aliaser to use.
    *
-   * `DefaultNamespaceAliaser` is used when omitted.
+   * Default `NamespaceAliaser` used when omitted.
    */
   readonly nsAlias?: NamespaceAliaser;
 

--- a/src/element-id-class.impl.ts
+++ b/src/element-id-class.impl.ts
@@ -1,6 +1,6 @@
-import { css__naming, NamespaceDef, QualifiedName } from '@frontmeans/namespace-aliaser';
+import { css__naming, NamespaceAliaser, NamespaceDef, QualifiedName } from '@frontmeans/namespace-aliaser';
 import { CxEntry, cxSingle } from '@proc7ts/context-values';
-import { ComponentContext, DefaultNamespaceAliaser, DefinitionContext } from '@wesib/wesib';
+import { ComponentContext, DefinitionContext } from '@wesib/wesib';
 
 export type ElementIdClass = QualifiedName;
 
@@ -21,7 +21,7 @@ let uniqueClassSeq = 0;
 
 function ElementIdClass$byDefault(target: CxEntry.Target<ElementIdClass>): ElementIdClass {
 
-  const nsAlias = target.get(DefaultNamespaceAliaser);
+  const nsAlias = target.get(NamespaceAliaser);
   const context = target.get(ComponentContext);
   const { tagName = 'component' } = context.get(DefinitionContext).elementDef;
   const local = `${tagName}#${++uniqueClassSeq}`;

--- a/src/produce-style.amendment.spec.ts
+++ b/src/produce-style.amendment.spec.ts
@@ -1,17 +1,10 @@
 import { doqryText } from '@frontmeans/doqry';
-import { immediateRenderScheduler } from '@frontmeans/render-scheduler';
+import { immediateRenderScheduler, RenderScheduler } from '@frontmeans/render-scheduler';
 import { StypProperties, StypRenderer, stypRoot, StypRules } from '@frontmeans/style-producer';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { cxBuildAsset, cxConstAsset } from '@proc7ts/context-builder';
 import { trackValue } from '@proc7ts/fun-events';
-import {
-  Component,
-  ComponentContext,
-  ComponentDef,
-  DefaultRenderScheduler,
-  Feature,
-  ShadowContentRoot,
-} from '@wesib/wesib';
+import { Component, ComponentContext, ComponentDef, Feature, ShadowContentRoot } from '@wesib/wesib';
 import { testDefinition } from '@wesib/wesib/testing';
 import { SpyInstance } from 'jest-mock';
 import { ComponentStypDomFormat } from './component-styp-dom.format';
@@ -194,7 +187,7 @@ describe('@ProduceStyle', () => {
     @Component(def)
     @Feature({
       setup(setup) {
-        setup.provide(cxConstAsset(DefaultRenderScheduler, immediateRenderScheduler));
+        setup.provide(cxConstAsset(RenderScheduler, immediateRenderScheduler));
       },
     })
     class TestComponent {


### PR DESCRIPTION
- Utilize global `NamespaceAliaser`
- Utilize context entries defined in `@proc7ts/render-scheduler`
- Utilize `DocumentRenderKit` defined in `@frontmeans/drek`
